### PR TITLE
Switch done() to done-testing()

### DIFF
--- a/lib/PDF/Grammar/Doc/Actions.pm
+++ b/lib/PDF/Grammar/Doc/Actions.pm
@@ -80,7 +80,7 @@ class PDF::Grammar::Doc::Actions
     }
 
     method body($/) {
-        my %body = (:objects[ $<ind-obj>>>.ast ],
+        my %body = flat (:objects[ $<ind-obj>>>.ast ],
                     ($<startxref> ?? $<startxref>.ast !! () ),
                     ($<index>.defined ?? @( $<index>.ast ) !! () ),
             );
@@ -89,7 +89,7 @@ class PDF::Grammar::Doc::Actions
     }
 
     method index($/) {
-        my %index = ($<xref>.defined ?? $<xref>.ast !! (),
+        my %index = flat ($<xref>.defined ?? $<xref>.ast !! (),
                      $<trailer>.ast);
         make %index;
     }

--- a/t/00objects.t
+++ b/t/00objects.t
@@ -94,4 +94,4 @@ for @tests {
     PDF::Grammar::Test::parse-tests(PDF::Grammar, $input, :$rule, :$actions, :suite($rule), :%expected );
 }
 
-done;
+done-testing;

--- a/t/content-ops.t
+++ b/t/content-ops.t
@@ -157,4 +157,4 @@ for (
        "parsed as unknown: " ~ .key);
 }
 
-done;
+done-testing;

--- a/t/content-parse.t
+++ b/t/content-parse.t
@@ -143,4 +143,4 @@ for (trivial => [$sample_content1, $ast1],
     }
 }
 
-done;
+done-testing;

--- a/t/fdf-parse.t
+++ b/t/fdf-parse.t
@@ -80,4 +80,4 @@ for (
     PDF::Grammar::Test::parse-tests(PDF::Grammar::FDF, %expected<input>, :$actions, :$rule, :suite("fdf {$test-name}"), :%expected );
 }
 
-done;
+done-testing;

--- a/t/function-parse.t
+++ b/t/function-parse.t
@@ -44,4 +44,4 @@ for ([ :$trivial-expr, $trivial-ast],
                                     :suite("functions - $name"), :%expected );
 }
 
-done;
+done-testing;

--- a/t/pdf-components.t
+++ b/t/pdf-components.t
@@ -158,4 +158,4 @@ for (unix => $nix-pdf,
          or diag :$trailer-ast.perl;
 }
 
-done;
+done-testing;

--- a/t/pdf-objects.t
+++ b/t/pdf-objects.t
@@ -166,4 +166,4 @@ for (
      PDF::Grammar::Test::parse-tests(PDF::Grammar::PDF, $input, :$rule, :$actions, :suite('pdf doc'), :%expected );
 }
 
-done;
+done-testing;

--- a/t/pdf-parsefile.t
+++ b/t/pdf-parsefile.t
@@ -17,4 +17,4 @@ my $p = PDF::Grammar::PDF.parsefile($pdf-file);
 
 ok($p, "parsed pdf content ($pdf-file)");
 
-done;
+done-testing;

--- a/t/pdf-regex.t
+++ b/t/pdf-regex.t
@@ -314,4 +314,4 @@ for ('null') {
     ok($_ ~~ /^<PDF::Grammar::PDF::object>$/, "object: $_");
 }
 
-done;
+done-testing;


### PR DESCRIPTION
Rakudo HEAD uses done-testing instead of done, so follow that.

Also add two flat() calls that are necessary after the Great List Refactor in Rakudo
(only a partial fix; two tests still fail in the rakudo "glr" branch)
